### PR TITLE
Add emailServiceName to config example

### DIFF
--- a/data/config.json.example
+++ b/data/config.json.example
@@ -152,6 +152,10 @@
        {
          "label": "emailSender",
          "value": "User <sender@myserver.com>"
+       },
+       {
+         "label": "emailServiceName",
+         "value": "Mailgun"
        }
       ],
       "isEnabled": true


### PR DESCRIPTION
fixes https://github.com/Shippable/base/issues/170