### PR TITLE
#349; adds consoleMaxLifespan.

### DIFF
--- a/data/config.json.example
+++ b/data/config.json.example
@@ -34,7 +34,8 @@
     "allowDynamicNodes": false,
     "allowCustomNodes": false,
     "systemNodePrivateKey": "",
-    "systemNodePublicKey": ""
+    "systemNodePublicKey": "",
+    "consoleMaxLifespan": 0
   },
   "providers": [
     {

--- a/data/state.json.example
+++ b/data/state.json.example
@@ -40,6 +40,7 @@
     "wwwUrl": "http://domain",
     "serviceUserToken": "",
     "swarmWorkerToken": "",
+    "consoleMaxLifespan": 0,
     "rootQueueList": "www.sockets|core.charon|versions.trigger|core.nf|nf.email|core.braintree|core.certgen|core.marshaller|marshaller.ec2|core.sync|job.request|job.trigger|micro.ini|cluster.init|steps.deploy|steps.manifest|steps.rSync|steps.release"
   },
   "installStatus": {},

--- a/scripts/bootstrapApp.sh
+++ b/scripts/bootstrapApp.sh
@@ -192,6 +192,10 @@ generate_system_config() {
     local allow_custom_nodes=$(cat $STATE_FILE | jq -r '.systemSettings.allowCustomNodes')
     sed -i "s#{{ALLOW_CUSTOM_NODES}}#$allow_custom_nodes#g" $system_configs_sql
 
+    __process_msg "Updating : consoleMaxLifespan"
+    local console_max_lifespan=$(cat $STATE_FILE | jq -r '.systemSettings.consoleMaxLifespan')
+    sed -i "s#{{CONSOLE_MAX_LIFESPAN}}#console_max_lifespan#g" $system_configs_sql
+
     _update_install_status "systemConfigSqlCreated"
     __process_msg "Successfully generated 'systemConfig' table data"
   else

--- a/scripts/remote/migrations.sql
+++ b/scripts/remote/migrations.sql
@@ -2150,6 +2150,11 @@ do $$
       alter table "systemConfigs" add column "allowCustomNodes" BOOLEAN default false;
     end if;
 
+    -- Adds consoleMaxLifespan column in systemConfigs table
+    if not exists (select 1 from information_schema.columns where table_name = 'systemConfigs' and column_name = 'consoleMaxLifespan') then
+      alter table "systemConfigs" add column "consoleMaxLifespan" INTEGER default 0;
+    end if;
+
     -- Drop projectPermissions
     drop table if exists "projectPermissions";
 

--- a/scripts/remote/systemConfigsData.sql.template
+++ b/scripts/remote/systemConfigsData.sql.template
@@ -30,7 +30,8 @@ do $$
             "systemNodePublicKey"='{{SYSTEM_NODE_PUBLIC_KEY}}',
             "allowSystemNodes"={{ALLOW_SYSTEM_NODES}},
             "allowDynamicNodes"={{ALLOW_DYNAMIC_NODES}},
-            "allowCustomNodes"={{ALLOW_CUSTOM_NODES}}
+            "allowCustomNodes"={{ALLOW_CUSTOM_NODES}},
+            "consoleMaxLifespan"={{CONSOLE_MAX_LIFESPAN}}
         where id=1;
     end if;
 
@@ -73,7 +74,8 @@ do $$
             "systemNodePublicKey",
             "allowSystemNodes",
             "allowDynamicNodes",
-            "allowCustomNodes"
+            "allowCustomNodes",
+            "consoleMaxLifespan"
           )
         values
           (
@@ -106,7 +108,8 @@ do $$
             '{{SYSTEM_NODE_PUBLIC_KEY}}',
             {{ALLOW_SYSTEM_NODES}},
             {{ALLOW_DYNAMIC_NODES}},
-            {{ALLOW_CUSTOM_NODES}}
+            {{ALLOW_CUSTOM_NODES}},
+            {{CONSOLE_MAX_LIFESPAN}}
           );
     end if;
   end

--- a/scripts/remote/system_configs.sql
+++ b/scripts/remote/system_configs.sql
@@ -51,6 +51,9 @@ do $$
       alter table "systemConfigs" add column "allowCustomNodes" BOOLEAN default false;
     end if;
 
+    if not exists (select 1 from information_schema.columns where table_name = 'systemConfigs' and column_name = 'consoleMaxLifespan') then
+      alter table "systemConfigs" add column "consoleMaxLifespan" INT default 0;
+    end if;
 
     alter table "systemConfigs" owner to "apiuser";
   end


### PR DESCRIPTION
#349 

Matches `hubspotEnabled` and `allowCustomNodes`.  The default is `0`, which represents never removing the console logs.