### PR TITLE
Correctly set systemConfigs.customHostDockerVersion; type VARCHAR(24)…

### DIFF
--- a/usr/system_configs.sql.template
+++ b/usr/system_configs.sql.template
@@ -67,8 +67,12 @@ do $$
       -- add default value
     end if;
 
+    if exists (select 1 from information_schema.columns where table_name = 'systemConfigs' and column_name = 'customHostDockerVersion' and data_type = 'integer') then
+      alter table "systemConfigs" alter column "customHostDockerVersion" type VARCHAR(24);
+    end if;
+
     if not exists (select 1 from information_schema.columns where table_name = 'systemConfigs' and column_name = 'customHostDockerVersion') then
-      alter table "systemConfigs" add column "customHostDockerVersion" INT;
+      alter table "systemConfigs" add column "customHostDockerVersion" VARCHAR(24);
       -- add default value
     end if;
 
@@ -111,7 +115,7 @@ do $$
             "allowCustomNodes"={{ALLOW_CUSTOM_NODES}},
             "consoleMaxLifespan"={{CONSOLE_MAX_LIFESPAN}},
             "consoleCleanupHour"={{CONSOLE_CLEANUP_HOUR}},
-            "customHostDockerVersion"={{CONSOLE_CLEANUP_HOUR}}
+            "customHostDockerVersion"={{CUSTOM_HOST_DOCKER_VERSION}}
         where id=1;
     end if;
 
@@ -156,7 +160,8 @@ do $$
             "allowDynamicNodes",
             "allowCustomNodes",
             "consoleMaxLifespan",
-            "consoleCleanupHour"
+            "consoleCleanupHour",
+            "customHostDockerVersion"
           )
         values
           (
@@ -191,7 +196,8 @@ do $$
             {{ALLOW_DYNAMIC_NODES}},
             {{ALLOW_CUSTOM_NODES}},
             {{CONSOLE_MAX_LIFESPAN}},
-            {{CONSOLE_CLEANUP_HOUR}}
+            {{CONSOLE_CLEANUP_HOUR}},
+            '{{CUSTOM_HOST_DOCKER_VERSION}}'
           );
     end if;
   end


### PR DESCRIPTION
https://github.com/Shippable/base/issues/489

- Updates the systemConfigs.customHostDockerVersion to be VARCHAR(24) (as it is in the model in api), instead of INT.
- Also updates bootstrapApp.js to use CUSTOM_HOST_DOCKER_VERTSION as the value, not CONSOLE_CLEANUP_HOUR.

Tested by running the installer and making the generate_system_config function run. The resulting system_configs.sql had the correct value and type for customHostDockerVersion. Also, the customHostDockerVersion column in the systemConfigs table was varchar(24).