### PR TITLE
Add routePermissions for /projects/:id/owners

### DIFF
--- a/migrations/v4.11.3.sql
+++ b/migrations/v4.11.3.sql
@@ -4168,6 +4168,15 @@ do $$
     );
 
     perform set_route_permission(
+      routePattern := '/projects/:id/owners',
+      httpVerb := 'GET',
+      roleCode := 6020,
+      isPublic := false,
+      isSuperUser := false,
+      isFreeUser := false
+    );
+
+    perform set_route_permission(
       routePattern := '/projects/:id/validOwner',
       httpVerb := 'GET',
       roleCode := null,


### PR DESCRIPTION
https://github.com/Shippable/base/issues/549

- Adds routePermissions for /projects/:id/owners
- Only accessible by project owners, not collaborators or members

tested by running the migration on the local db; the correct route permission was created.