### PR TITLE
fixing route permissions for account routes

### DIFF
--- a/migrations/v4.12.0.sql
+++ b/migrations/v4.12.0.sql
@@ -6009,23 +6009,11 @@ do $$
     perform set_route_role(
       routePattern := '/accounts',
       httpVerb := 'GET',
-      roleCode := 6000
+      roleCode := 6060
     );
 
     perform set_route_role(
-      routePattern := '/accounts',
-      httpVerb := 'GET',
-      roleCode := 6010
-    );
-
-    perform set_route_role(
-      routePattern := '/accounts',
-      httpVerb := 'GET',
-      roleCode := 6020
-    );
-
-    perform set_route_role(
-      routePattern := '/accounts',
+      routePattern := '/accounts/:id',
       httpVerb := 'GET',
       roleCode := 6060
     );

--- a/migrations/v4.12.0.sql
+++ b/migrations/v4.12.0.sql
@@ -6017,5 +6017,48 @@ do $$
       httpVerb := 'GET',
       roleCode := 6060
     );
+
+    perform set_route_role(
+      routePattern := '/accounts/:id/dependencies',
+      httpVerb := 'GET',
+      roleCode := 6060
+    );
+
+    perform set_route_role(
+      routePattern := '/accounts/:id/sync',
+      httpVerb := 'GET',
+      roleCode := 6060
+    );
+
+    perform set_route_role(
+      routePattern := '/accounts/:id/generateSSHKeys',
+      httpVerb := 'POST',
+      roleCode := 6060
+    );
+
+    perform set_route_role(
+      routePattern := '/accounts/:id',
+      httpVerb := 'PUT',
+      roleCode := 6060
+    );
+
+    perform set_route_role(
+      routePattern := '/accounts/:id',
+      httpVerb := 'DELETE',
+      roleCode := 6060
+    );
+
+    perform set_route_role(
+      routePattern := '/accounts/auth/:systemIntegrationId',
+      httpVerb := 'POST',
+      roleCode := 6060
+    );
+
+    perform set_route_role(
+      routePattern := '/accounts/auth/:systemIntegrationId/link',
+      httpVerb := 'POST',
+      roleCode := 6060
+    );
+
   end
 $$;


### PR DESCRIPTION
- https://github.com/Shippable/base/issues/589
- since there is no `member`, `collaborator` or `admin` access control on accounts, we dont need to add the permissions for those. the only permission that needs to be checked is whether the user has `justUser` role. 