### PR TITLE
#601 and #602; adds routeRoles for projects routes to be updated.

### DIFF
--- a/migrations/v4.12.0.sql
+++ b/migrations/v4.12.0.sql
@@ -6075,6 +6075,79 @@ do $$
       roleCode := 6060
     );
 
+    -- set projects routeRoles
+    perform set_route_role(
+      routePattern := '/projects',
+      httpVerb := 'GET',
+      roleCode := 6000
+    );
+
+    perform set_route_role(
+      routePattern := '/projects',
+      httpVerb := 'GET',
+      roleCode := 6010
+    );
+
+    perform set_route_role(
+      routePattern := '/projects',
+      httpVerb := 'GET',
+      roleCode := 6020
+    );
+
+    perform set_route_role(
+      routePattern := '/projects',
+      httpVerb := 'GET',
+      roleCode := 6040
+    );
+
+    perform set_route_role(
+      routePattern := '/projects',
+      httpVerb := 'GET',
+      roleCode := 6060
+    );
+
+    perform set_route_role(
+      routePattern := '/projects/:projectId',
+      httpVerb := 'GET',
+      roleCode := 6000
+    );
+
+    perform set_route_role(
+      routePattern := '/projects/:projectId',
+      httpVerb := 'GET',
+      roleCode := 6010
+    );
+
+    perform set_route_role(
+      routePattern := '/projects/:projectId',
+      httpVerb := 'GET',
+      roleCode := 6020
+    );
+
+    perform set_route_role(
+      routePattern := '/projects/:projectId',
+      httpVerb := 'GET',
+      roleCode := 6040
+    );
+
+    perform set_route_role(
+      routePattern := '/projects/:projectId',
+      httpVerb := 'GET',
+      roleCode := 6060
+    );
+
+    perform set_route_role(
+      routePattern := '/projects/:projectId/disable',
+      httpVerb := 'POST',
+      roleCode := 6020
+    );
+
+    perform set_route_role(
+      routePattern := '/projects/:projectId/disable',
+      httpVerb := 'POST',
+      roleCode := 6060
+    );
+
     -- set subscriptions routeRoles
 
     perform set_route_role(


### PR DESCRIPTION
#601 and #602 

Adds routeRoles for `GET /projects`, `GET /projects/:projectId`, and `POST /projects/:projectId/disable`.  The roles in the database appear to be correct.