### PR TITLE
adds routeRoles for POST /accountIntegration

### DIFF
--- a/migrations/v4.12.1.sql
+++ b/migrations/v4.12.1.sql
@@ -6302,5 +6302,11 @@ do $$
       roleCode := 6060
     );
 
+    perform set_route_role(
+      routePattern := '/accountIntegrations',
+      httpVerb := 'POST',
+      roleCode := 6060
+    );
+
   end
 $$;


### PR DESCRIPTION
https://github.com/Shippable/base/issues/616

according to the routing permissions table, POST /accountIntegrations needs the following entries

```
perform set_route_role(
  routePattern := '/accountIntegrations',
  httpVerb := 'POST',
  roleCode := 6000
);

perform set_route_role(
  routePattern := '/accountIntegrations',
  httpVerb := 'POST',
  roleCode := 6010
);

perform set_route_role(
  routePattern := '/accountIntegrations',
  httpVerb := 'POST',
  roleCode := 6020
);
```

member, collaborator and admin permissions.

But, accountIntegrations POST is happening only in UI of loggedIn user. So, I have added only the permission for `justUser`. 

# QUESTIONS
1) is the logic right ? Do we need only `justUser` permission ?
2) If not, what is the real use of having member, collaborator and admin roles ?