### PR TITLE
Add routeRoles for vortex

### DIFF
--- a/migrations/v4.12.1.sql
+++ b/migrations/v4.12.1.sql
@@ -6392,5 +6392,19 @@ do $$
       roleCode := 6060
     );
 
+    -- set vortex routeRoles
+
+    perform set_route_role(
+      routePattern := '/vortex',
+      httpVerb := 'POST',
+      roleCode := 6060
+    );
+
+    perform set_route_role(
+      routePattern := '/vortex',
+      httpVerb := 'GET',
+      roleCode := 6060
+    );
+
   end
 $$;


### PR DESCRIPTION
https://github.com/Shippable/base/issues/637

- Adds justUser routeRoles for GET and POST /vortex

Tested by running the install from scratch; the routeRoles were created in the db.