### PR TITLE
Add routeRoles for GET /subscriptions/:subscriptionId

### DIFF
--- a/migrations/v4.12.1.sql
+++ b/migrations/v4.12.1.sql
@@ -6297,6 +6297,36 @@ do $$
     );
 
     perform set_route_role(
+      routePattern := '/subscriptions/:subscriptionId',
+      httpVerb := 'GET',
+      roleCode := 6000
+    );
+
+    perform set_route_role(
+      routePattern := '/subscriptions/:subscriptionId',
+      httpVerb := 'GET',
+      roleCode := 6010
+    );
+
+    perform set_route_role(
+      routePattern := '/subscriptions/:subscriptionId',
+      httpVerb := 'GET',
+      roleCode := 6020
+    );
+
+    perform set_route_role(
+      routePattern := '/subscriptions/:subscriptionId',
+      httpVerb := 'GET',
+      roleCode := 6040
+    );
+
+    perform set_route_role(
+      routePattern := '/subscriptions/:subscriptionId',
+      httpVerb := 'GET',
+      roleCode := 6060
+    );
+
+    perform set_route_role(
       routePattern := '/subscriptions/:subscriptionId/reset',
       httpVerb := 'POST',
       roleCode := 6020


### PR DESCRIPTION
https://github.com/Shippable/base/issues/652

Adds routeRoles for GET /subscriptions/:subscriptionId

Tested by running the installer from scratch; it succeeded, and the roles were created in the db.