### PR TITLE
Restart API following migration.

### DIFF
--- a/usr/state.json.example
+++ b/usr/state.json.example
@@ -2,6 +2,7 @@
   "release": "",
   "deployTag": "",
   "installMode": "local",
+  "isUpgrade": false,
   "masterIntegrations": [
     {
       "name": "S3",


### PR DESCRIPTION
There are a few changes here:
* If a release is being made, migrations run _before_ API boots up. This will allow any fields that the API needs to be added.
* If an install is being made, migrations runs _after_ API boots up, as the tables required for migrations are created by the API.
* API restarts following this to cache any new values.

Fixes https://github.com/Shippable/base/issues/658