### PR TITLE
using replica count from state file

### DIFF
--- a/scripts/_manageServices.sh
+++ b/scripts/_manageServices.sh
@@ -5,19 +5,43 @@ release_file="$VERSIONS_DIR/$RELEASE_VERSION".json
 __add_service() {
   local service_name="$1"
 
-  local service=$(cat $release_file | jq -c '.serviceConfigs[] | select (.name=='$service_name')')
+  local service=$(cat $release_file \
+    | jq -c '.serviceConfigs[] | select (.name=='$service_name')')
+
   if [ ! -z "$service" ]; then
-    service=$(cat $STATE_FILE | jq '.services[] | select (.name=='$service_name')')
-    if [ -z "$service" ]; then
+    __process_msg "service $service_name present in release file"
+    local service_state=$(cat $STATE_FILE \
+      | jq '.services[] | select (.name=='$service_name')')
+
+    if [ -z "$service_state" ]; then
       __process_msg "no $service_name service in state.json, creating new one"
-      service=$(cat $STATE_FILE |  \
-        jq '.services |= . + [{
-          "name": '$service_name',
-          "image": "",
-          "env": ""
-        }]')
-      update=$(echo $service | jq '.' | tee $STATE_FILE)
+      local is_service_global=$(echo $service \
+        | jq -r '.isGlobal')
+      if [ "$is_service_global" == true ]; then
+        __process_msg "service $service_name is global, not setting default replica count"
+        service_state=$(cat $STATE_FILE |  \
+          jq '.services |= . + [{
+            "name": '$service_name',
+            "image": "",
+            "env": ""
+          }]')
+      else
+        __process_msg "service $service_name not global, setting default replica count"
+        service_state=$(cat $STATE_FILE |  \
+          jq '.services |= . + [{
+            "name": '$service_name',
+            "image": "",
+            "env": "",
+            "replicas": 1
+          }]')
+      fi
+      update=$(echo $service_state | jq '.' | tee $STATE_FILE)
+    else
+      __process_msg "service $service_name already present in state file"
     fi
+  else
+    __process_msg "Error!!! service $service_name not present in release file"
+    exit 1
   fi
 }
 
@@ -44,11 +68,26 @@ add_master_integration_services() {
   done
 }
 
+configure_replicas() {
+  __process_msg "Configuring replicas for services"
+  local replicas_configured=$(cat $STATE_FILE | jq -r '.installStatus.replicasConfigured')
+
+  if [ $replicas_configured == true ]; then
+    __process_msg "Service replicas already configured, skipping"
+  else
+    __process_msg "Service replicas configuration required"
+    __process_msg "Please set the desired replica count in 'services[]' array in 'usr/state.json' file"
+    __process_msg "Once completed, set 'installStatus.replicasConfigure=true' and re-run installer"
+    exit 1
+  fi
+}
+
 main() {
   __process_marker "Configuring services list"
 
   add_core_services
   add_master_integration_services
+  configure_replicas
   __process_msg "Configured services list"
 }
 

--- a/scripts/_manageServices.sh
+++ b/scripts/_manageServices.sh
@@ -17,6 +17,7 @@ __add_service() {
       __process_msg "no $service_name service in state.json, creating new one"
       local is_service_global=$(echo $service \
         | jq -r '.isGlobal')
+
       if [ "$is_service_global" == true ]; then
         __process_msg "service $service_name is global, not setting default replica count"
         service_state=$(cat $STATE_FILE |  \

--- a/scripts/provisionServices.sh
+++ b/scripts/provisionServices.sh
@@ -207,26 +207,6 @@ __save_service_config() {
   )
   update=$(echo $state_env | jq '.' | tee $STATE_FILE)
 
-  __process_msg "Generating $service replicas"
-  local replicas=$(cat $release_file | jq --arg service "$service" '
-    .serviceConfigs[] |
-    select (.name==$service) | .replicas')
-
-  if [ $replicas != "null" ]; then
-    __process_msg "Found $replicas for $service"
-    local replicas_update=$(cat $STATE_FILE | jq --arg service "$service" '
-      .services  |=
-      map(if .name == $service then
-          .replicas = "'$replicas'"
-        else
-          .
-        end
-      )'
-    )
-    update=$(echo $replicas_update | jq '.' | tee $STATE_FILE)
-    __process_msg "Successfully updated $service replicas"
-  fi
-
   local volumes=$(cat $release_file | jq --arg service "$service" '
     .serviceConfigs[] |
     select (.name==$service) | .volumes')
@@ -401,7 +381,7 @@ __run_service() {
 
 provision_www() {
   local sleep_time=30
-  __save_service_config www " --publish 50001:50001/tcp" " --name www --network ingress --with-registry-auth --endpoint-mode vip"
+  __save_service_config www " --publish 50001:50001/tcp" "--mode global --name www --network ingress --with-registry-auth --endpoint-mode vip"
   __run_service "www" $sleep_time
 }
 

--- a/usr/state.json.example
+++ b/usr/state.json.example
@@ -512,6 +512,7 @@
   "machines": [],
   "installStatus": {
     "machinesSSHSuccessful": false,
+    "replicasConfigured": false,
     "machinesBootstrapped": false,
     "databaseInstalled": false,
     "databaseInitialized": false,

--- a/versions/v4.12.1.json
+++ b/versions/v4.12.1.json
@@ -254,6 +254,7 @@
     {
       "name": "api",
       "repository": "api",
+      "isGlobal": true,
       "envs": [
         "DBNAME",
         "DBUSERNAME",
@@ -267,6 +268,7 @@
     {
       "name": "www",
       "repository": "www",
+      "isGlobal": true,
       "envs": [
         "SHIPPABLE_API_TOKEN",
         "SHIPPABLE_VORTEX_URL",
@@ -286,7 +288,6 @@
     {
       "name": "nexec",
       "repository": "nexec",
-      "replicas": 1,
       "envs": [
         "SHIPPABLE_API_TOKEN",
         "SHIPPABLE_VORTEX_URL",
@@ -299,7 +300,6 @@
     {
       "name": "braintree",
       "repository": "micro",
-      "replicas": 1,
       "envs": [
         "SHIPPABLE_API_TOKEN",
         "SHIPPABLE_API_URL",
@@ -312,7 +312,6 @@
     {
       "name": "certgen",
       "repository": "micro",
-      "replicas": 1,
       "envs": [
         "SHIPPABLE_API_TOKEN",
         "SHIPPABLE_API_URL",
@@ -325,7 +324,6 @@
     {
       "name": "charon",
       "repository": "micro",
-      "replicas": 1,
       "envs": [
         "SHIPPABLE_API_TOKEN",
         "SHIPPABLE_API_URL",
@@ -338,7 +336,6 @@
     {
       "name": "cron",
       "repository": "micro",
-      "replicas": 1,
       "envs": [
         "SHIPPABLE_API_TOKEN",
         "SHIPPABLE_API_URL",
@@ -352,7 +349,6 @@
     {
       "name": "ec2",
       "repository": "micro",
-      "replicas": 1,
       "envs": [
         "SHIPPABLE_API_TOKEN",
         "SHIPPABLE_API_URL",
@@ -372,7 +368,6 @@
     {
       "name": "email",
       "repository": "micro",
-      "replicas": 1,
       "envs": [
         "SHIPPABLE_API_TOKEN",
         "SHIPPABLE_API_URL",
@@ -386,7 +381,6 @@
     {
       "name": "hipchat",
       "repository": "micro",
-      "replicas": 1,
       "envs": [
         "SHIPPABLE_API_TOKEN",
         "SHIPPABLE_API_URL",
@@ -400,7 +394,6 @@
     {
       "name": "hubspotSync",
       "repository": "micro",
-      "replicas": 1,
       "envs": [
         "SHIPPABLE_API_TOKEN",
         "SHIPPABLE_API_URL",
@@ -416,7 +409,6 @@
     {
       "name": "ini",
       "repository": "micro",
-      "replicas": 1,
       "envs": [
         "SHIPPABLE_API_TOKEN",
         "SHIPPABLE_API_URL",
@@ -429,7 +421,6 @@
     {
       "name": "irc",
       "repository": "micro",
-      "replicas": 1,
       "envs": [
         "SHIPPABLE_ROOT_AMQP_URL",
         "SHIPPABLE_AMQP_DEFAULT_EXCHANGE",
@@ -445,7 +436,6 @@
     {
       "name": "jobRequest",
       "repository": "micro",
-      "replicas": 1,
       "envs": [
         "SHIPPABLE_API_TOKEN",
         "SHIPPABLE_API_URL",
@@ -459,7 +449,6 @@
     {
       "name": "jobTrigger",
       "repository": "micro",
-      "replicas": 1,
       "envs": [
         "SHIPPABLE_API_TOKEN",
         "SHIPPABLE_API_URL",
@@ -474,7 +463,6 @@
     {
       "name": "jSync",
       "repository": "micro",
-      "replicas": 1,
       "envs": [
         "SHIPPABLE_API_TOKEN",
         "SHIPPABLE_API_URL",
@@ -487,7 +475,6 @@
     {
       "name": "marshaller",
       "repository": "micro",
-      "replicas": 1,
       "envs": [
         "SHIPPABLE_API_TOKEN",
         "SHIPPABLE_API_URL",
@@ -502,7 +489,6 @@
     {
       "name": "nf",
       "repository": "micro",
-      "replicas": 1,
       "envs": [
         "SHIPPABLE_API_TOKEN",
         "SHIPPABLE_API_URL",
@@ -516,7 +502,6 @@
     {
       "name": "slack",
       "repository": "micro",
-      "replicas": 1,
       "envs": [
         "SHIPPABLE_API_TOKEN",
         "SHIPPABLE_API_URL",
@@ -530,7 +515,6 @@
     {
       "name": "deploy",
       "repository": "micro",
-      "replicas": 3,
       "envs": [
         "SHIPPABLE_API_TOKEN",
         "SHIPPABLE_API_URL",
@@ -544,7 +528,6 @@
     {
       "name": "manifest",
       "repository": "micro",
-      "replicas": 2,
       "envs": [
         "SHIPPABLE_API_TOKEN",
         "SHIPPABLE_API_URL",
@@ -558,7 +541,6 @@
     {
       "name": "release",
       "repository": "micro",
-      "replicas": 2,
       "envs": [
         "SHIPPABLE_API_TOKEN",
         "SHIPPABLE_API_URL",
@@ -572,7 +554,6 @@
     {
       "name": "rSync",
       "repository": "micro",
-      "replicas": 2,
       "envs": [
         "SHIPPABLE_API_TOKEN",
         "SHIPPABLE_API_URL",
@@ -586,7 +567,6 @@
     {
       "name": "sync",
       "repository": "micro",
-      "replicas": 2,
       "envs": [
         "SHIPPABLE_ROOT_AMQP_URL",
         "SHIPPABLE_AMQP_DEFAULT_EXCHANGE",
@@ -599,7 +579,6 @@
     {
       "name": "timeTrigger",
       "repository": "micro",
-      "replicas": 1,
       "envs": [
         "SHIPPABLE_ROOT_AMQP_URL",
         "SHIPPABLE_AMQP_DEFAULT_EXCHANGE",
@@ -612,7 +591,6 @@
     {
       "name": "versionTrigger",
       "repository": "micro",
-      "replicas": 1,
       "envs": [
         "SHIPPABLE_ROOT_AMQP_URL",
         "SHIPPABLE_AMQP_DEFAULT_EXCHANGE",
@@ -625,7 +603,6 @@
     {
       "name": "webhook",
       "repository": "micro",
-      "replicas": 1,
       "envs": [
         "SHIPPABLE_ROOT_AMQP_URL",
         "SHIPPABLE_AMQP_DEFAULT_EXCHANGE",


### PR DESCRIPTION
- https://github.com/Shippable/base/issues/780
- for a new installation, user will be prompted to set the replicas count. if the user wants to set default, then they'll set `installStatus.replicasConfigured=true` in state file
- for updating an existing installation, no action is required. all upgrades will use the configured replica count for services
- for updating from an older version of installer, state file needs `installStatus.replicasConfigured=true` flag to be set