### PR TITLE
Add provision as a GKE integration service

### DIFF
--- a/versions/v5.1.4.json
+++ b/versions/v5.1.4.json
@@ -74,7 +74,9 @@
     {
       "name": "GKE",
       "type": "deploy",
-      "services": []
+      "services": [
+        "provision"
+      ]
     },
     {
       "name": "TRIPUB",

--- a/versions/v5.1.5.json
+++ b/versions/v5.1.5.json
@@ -74,7 +74,9 @@
     {
       "name": "GKE",
       "type": "deploy",
-      "services": []
+      "services": [
+        "provision"
+      ]
     },
     {
       "name": "TRIPUB",


### PR DESCRIPTION
https://github.com/Shippable/base/issues/915

- Adds provision as a GKE integration service

Tested by upgrading a local installation to 5.1.4; the provision microservice was created and it connected to the queue.