### PR TITLE
#926; sets builderAccountId when ownerAccountId is available.

### DIFF
--- a/migrations/v5.1.5.sql
+++ b/migrations/v5.1.5.sql
@@ -2017,6 +2017,9 @@ do $$
       alter table "projects" add column "builderAccountId" varchar(24);
     end if;
 
+    -- Set builderAccountId for projects with only a ownerAccountId
+      UPDATE projects SET "builderAccountId" = "ownerAccountId" WHERE "builderAccountId" IS NULL AND "ownerAccountId" IS NOT NULL;
+
     -- Adds foreign key relationships for projects
     if not exists (select 1 from pg_constraint where conname = 'projects_enabledBy_fkey') then
       update projects as p set "enabledBy"=(select id from accounts where "id"=p."enabledBy");


### PR DESCRIPTION
#926 

Tested by running the migration script a few times and checking that the `builderAccountId` was only set by the script on projects that did not already have a `builderAccountId` and then re-installing.  The migration is needed for installations with `autoSelectBuilderToken` false so that webhooks will function if already-enabled projects don't have a `builderAccountId` before upgrading.