### PR TITLE
Ensure table exists before running migration

### DIFF
--- a/migrations/v5.1.5.sql
+++ b/migrations/v5.1.5.sql
@@ -1934,10 +1934,12 @@ do $$
      end if;
 
    -- Adds accountRole for serviceUser
-     if not exists (select 1 from "accountRoles" where "accountId" = '540e55445e5bad6f98764522' and "roleCode" = 6100) then
-       insert into "accountRoles" ("accountId", "roleCode", "createdAt", "updatedAt")
-       values ('540e55445e5bad6f98764522', 6100, '2016-02-29T00:00:00Z', '2016-02-29T00:00:00Z');
+    if exists (select 1 from information_schema.columns where table_name = 'accountRoles') then
+      if not exists (select 1 from "accountRoles" where "accountId" = '540e55445e5bad6f98764522' and "roleCode" = 6100) then
+        insert into "accountRoles" ("accountId", "roleCode", "createdAt", "updatedAt")
+        values ('540e55445e5bad6f98764522', 6100, '2016-02-29T00:00:00Z', '2016-02-29T00:00:00Z');
       end if;
+    end if;
 
   -- Adds serviceUser token in accountTokens table for local
      if not exists (select 1 from "accountTokens" where "name" = 'serviceUser' and "isInternal" = true) then
@@ -5289,41 +5291,43 @@ do $$
     end if;
 
     -- Moves accounts.systemRoles data to accountRoles table
-    if exists (select 1 from information_schema.columns where table_name = 'accounts' and column_name = 'systemRoles') then
-    begin
-    declare
-      accounts_rec record;
+    if exists (select 1 from information_schema.columns where table_name = 'accountRoles') then
+      if exists (select 1 from information_schema.columns where table_name = 'accounts' and column_name = 'systemRoles') then
       begin
-        for accounts_rec in select id, "systemRoles" as roles from accounts where "systemRoles" not like '["user"]' and "systemRoles" not like '[ "user" ]'
-        loop
-          if accounts_rec.roles like '%opsUser%' then
-            if not exists (select 1 from "accountRoles" where "accountId" = accounts_rec.id and "roleCode" = 6070) then
-              insert into "accountRoles" ("accountId", "roleCode", "createdAt", "updatedAt")
-              values (accounts_rec.id, 6070, '2016-06-01', '2016-06-01');
+      declare
+        accounts_rec record;
+        begin
+          for accounts_rec in select id, "systemRoles" as roles from accounts where "systemRoles" not like '["user"]' and "systemRoles" not like '[ "user" ]'
+          loop
+            if accounts_rec.roles like '%opsUser%' then
+              if not exists (select 1 from "accountRoles" where "accountId" = accounts_rec.id and "roleCode" = 6070) then
+                insert into "accountRoles" ("accountId", "roleCode", "createdAt", "updatedAt")
+                values (accounts_rec.id, 6070, '2016-06-01', '2016-06-01');
+              end if;
             end if;
-          end if;
-          if accounts_rec.roles like '%superUser%' then
-            if not exists (select 1 from "accountRoles" where "accountId" = accounts_rec.id and "roleCode" = 6080) then
-              insert into "accountRoles" ("accountId", "roleCode", "createdAt", "updatedAt")
-              values (accounts_rec.id, 6080, '2016-06-01', '2016-06-01');
+            if accounts_rec.roles like '%superUser%' then
+              if not exists (select 1 from "accountRoles" where "accountId" = accounts_rec.id and "roleCode" = 6080) then
+                insert into "accountRoles" ("accountId", "roleCode", "createdAt", "updatedAt")
+                values (accounts_rec.id, 6080, '2016-06-01', '2016-06-01');
+              end if;
             end if;
-          end if;
-          if accounts_rec.roles like '%betaUser%' then
-            if not exists (select 1 from "accountRoles" where "accountId" = accounts_rec.id and "roleCode" = 6090) then
-              insert into "accountRoles" ("accountId", "roleCode", "createdAt", "updatedAt")
-              values (accounts_rec.id, 6090, '2016-06-01', '2016-06-01');
+            if accounts_rec.roles like '%betaUser%' then
+              if not exists (select 1 from "accountRoles" where "accountId" = accounts_rec.id and "roleCode" = 6090) then
+                insert into "accountRoles" ("accountId", "roleCode", "createdAt", "updatedAt")
+                values (accounts_rec.id, 6090, '2016-06-01', '2016-06-01');
+              end if;
             end if;
-          end if;
-          if accounts_rec.roles like '%serviceUser%' then
-            if not exists (select 1 from "accountRoles" where "accountId" = accounts_rec.id and "roleCode" = 6100) then
-              insert into "accountRoles" ("accountId", "roleCode", "createdAt", "updatedAt")
-              values (accounts_rec.id, 6100, '2016-06-01', '2016-06-01');
+            if accounts_rec.roles like '%serviceUser%' then
+              if not exists (select 1 from "accountRoles" where "accountId" = accounts_rec.id and "roleCode" = 6100) then
+                insert into "accountRoles" ("accountId", "roleCode", "createdAt", "updatedAt")
+                values (accounts_rec.id, 6100, '2016-06-01', '2016-06-01');
+              end if;
             end if;
-          end if;
-        end loop;
+          end loop;
+        end;
+        alter table "accounts" drop column "systemRoles";
       end;
-      alter table "accounts" drop column "systemRoles";
-    end;
+      end if;
     end if;
 
     -- Drop Vault related fields from accounts table

--- a/migrations/v5.2.1.sql
+++ b/migrations/v5.2.1.sql
@@ -1966,10 +1966,12 @@ do $$
      end if;
 
    -- Adds accountRole for serviceUser
-     if not exists (select 1 from "accountRoles" where "accountId" = '540e55445e5bad6f98764522' and "roleCode" = 6100) then
-       insert into "accountRoles" ("accountId", "roleCode", "createdAt", "updatedAt")
-       values ('540e55445e5bad6f98764522', 6100, '2016-02-29T00:00:00Z', '2016-02-29T00:00:00Z');
+    if exists (select 1 from information_schema.columns where table_name = 'accountRoles') then
+      if not exists (select 1 from "accountRoles" where "accountId" = '540e55445e5bad6f98764522' and "roleCode" = 6100) then
+        insert into "accountRoles" ("accountId", "roleCode", "createdAt", "updatedAt")
+        values ('540e55445e5bad6f98764522', 6100, '2016-02-29T00:00:00Z', '2016-02-29T00:00:00Z');
       end if;
+    end if;
 
   -- Adds serviceUser token in accountTokens table for local
      if not exists (select 1 from "accountTokens" where "name" = 'serviceUser' and "isInternal" = true) then
@@ -5321,41 +5323,43 @@ do $$
     end if;
 
     -- Moves accounts.systemRoles data to accountRoles table
-    if exists (select 1 from information_schema.columns where table_name = 'accounts' and column_name = 'systemRoles') then
-    begin
-    declare
-      accounts_rec record;
+    if exists (select 1 from information_schema.columns where table_name = 'accountRoles') then
+      if exists (select 1 from information_schema.columns where table_name = 'accounts' and column_name = 'systemRoles') then
       begin
-        for accounts_rec in select id, "systemRoles" as roles from accounts where "systemRoles" not like '["user"]' and "systemRoles" not like '[ "user" ]'
-        loop
-          if accounts_rec.roles like '%opsUser%' then
-            if not exists (select 1 from "accountRoles" where "accountId" = accounts_rec.id and "roleCode" = 6070) then
-              insert into "accountRoles" ("accountId", "roleCode", "createdAt", "updatedAt")
-              values (accounts_rec.id, 6070, '2016-06-01', '2016-06-01');
+      declare
+        accounts_rec record;
+        begin
+          for accounts_rec in select id, "systemRoles" as roles from accounts where "systemRoles" not like '["user"]' and "systemRoles" not like '[ "user" ]'
+          loop
+            if accounts_rec.roles like '%opsUser%' then
+              if not exists (select 1 from "accountRoles" where "accountId" = accounts_rec.id and "roleCode" = 6070) then
+                insert into "accountRoles" ("accountId", "roleCode", "createdAt", "updatedAt")
+                values (accounts_rec.id, 6070, '2016-06-01', '2016-06-01');
+              end if;
             end if;
-          end if;
-          if accounts_rec.roles like '%superUser%' then
-            if not exists (select 1 from "accountRoles" where "accountId" = accounts_rec.id and "roleCode" = 6080) then
-              insert into "accountRoles" ("accountId", "roleCode", "createdAt", "updatedAt")
-              values (accounts_rec.id, 6080, '2016-06-01', '2016-06-01');
+            if accounts_rec.roles like '%superUser%' then
+              if not exists (select 1 from "accountRoles" where "accountId" = accounts_rec.id and "roleCode" = 6080) then
+                insert into "accountRoles" ("accountId", "roleCode", "createdAt", "updatedAt")
+                values (accounts_rec.id, 6080, '2016-06-01', '2016-06-01');
+              end if;
             end if;
-          end if;
-          if accounts_rec.roles like '%betaUser%' then
-            if not exists (select 1 from "accountRoles" where "accountId" = accounts_rec.id and "roleCode" = 6090) then
-              insert into "accountRoles" ("accountId", "roleCode", "createdAt", "updatedAt")
-              values (accounts_rec.id, 6090, '2016-06-01', '2016-06-01');
+            if accounts_rec.roles like '%betaUser%' then
+              if not exists (select 1 from "accountRoles" where "accountId" = accounts_rec.id and "roleCode" = 6090) then
+                insert into "accountRoles" ("accountId", "roleCode", "createdAt", "updatedAt")
+                values (accounts_rec.id, 6090, '2016-06-01', '2016-06-01');
+              end if;
             end if;
-          end if;
-          if accounts_rec.roles like '%serviceUser%' then
-            if not exists (select 1 from "accountRoles" where "accountId" = accounts_rec.id and "roleCode" = 6100) then
-              insert into "accountRoles" ("accountId", "roleCode", "createdAt", "updatedAt")
-              values (accounts_rec.id, 6100, '2016-06-01', '2016-06-01');
+            if accounts_rec.roles like '%serviceUser%' then
+              if not exists (select 1 from "accountRoles" where "accountId" = accounts_rec.id and "roleCode" = 6100) then
+                insert into "accountRoles" ("accountId", "roleCode", "createdAt", "updatedAt")
+                values (accounts_rec.id, 6100, '2016-06-01', '2016-06-01');
+              end if;
             end if;
-          end if;
-        end loop;
+          end loop;
+        end;
+        alter table "accounts" drop column "systemRoles";
       end;
-      alter table "accounts" drop column "systemRoles";
-    end;
+      end if;
     end if;
 
     -- Drop Vault related fields from accounts table


### PR DESCRIPTION
Looked at all migrations following v4.12.3, everything except "accountRoles" should be okay. The script isn't idempotent as we skip something if its not available, but it should allow the installation to continue.
To test this I did the following:
* Made a release of v4.12.3(ran twice to allow migrations to run correctly)
* Made a release of v5.1.5. Saw the error:
```
'/home/shrivara/shippable/base/migrations/v5.1.5.sql' -> '/home/shrivara/shippable/base/scripts/local/data/migrations.sql'
psql:/tmp/data/migrations.sql:2510: ERROR:  relation "accountRoles" does not exist
LINE 1: SELECT not exists (select 1 from "accountRoles" where "accou...
                                         ^
QUERY:  SELECT not exists (select 1 from "accountRoles" where "accountId" = '540e55445e5bad6f98764522' and "roleCode" = 6100)
CONTEXT:  PL/pgSQL function inline_code_block line 1937 at IF
```
* Added this fix, there were no errors.
* Ran the installer again, the accountRoles were generated correctly.

The diff looks a bit weird, but it just consists of one additional check. Will patch the release after all changes are merged.

https://github.com/Shippable/base/issues/947