### PR TITLE
removing sleep between api stop & start

### DIFF
--- a/scripts/bootstrapApp.sh
+++ b/scripts/bootstrapApp.sh
@@ -494,7 +494,6 @@ provision_api() {
   local rm_api_cmd="docker service rm api || true"
 
   _exec_remote_cmd "$swarm_manager_host" "$rm_api_cmd"
-  sleep 15
   _exec_remote_cmd "$swarm_manager_host" "$boot_api_cmd"
 }
 


### PR DESCRIPTION
https://github.com/Shippable/pm/issues/7995
Sleep was added because WWW was failing due to above PM issue. Since, it is resolved, we can remove the sleep.