### PR TITLE
Remove copy_node_scripts; update value for nodeScriptsLocation

### DIFF
--- a/usr/state.json.example
+++ b/usr/state.json.example
@@ -543,12 +543,11 @@
     "hubspotShouldSimulate": "true",
     "shippableAwsAccountId": "123456",
     "rootS3Bucket": "",
-    "nodeScriptsRemoteLocation": "https://github.com/Shippable/node/archive/RELEASE_VERSION.tar.gz",
-    "nodeScriptsLocation": "",
     "enforcePrivateJobQuota": false,
     "technicalSupportAvailable": false,
     "customNodesAdminOnly": false,
-    "mktgPort": 50002
+    "mktgPort": 50002,
+    "nodeScriptsLocation": "/home/shippable/scripts/node"
   },
   "machines": [],
   "installStatus": {


### PR DESCRIPTION
https://github.com/Shippable/base/issues/1133

- Removes nodeScriptsRemoteLocation from state.json
- Removes the copy_node_scripts function (and references); copying is now happening in api
- Fixes a couple typos in the `_map_env_vars` function in `bootstrapApp` (the typo wasn't affecting functionality, as it was reassigning the value of the same variable multiple times)

Tested by installing from scratch, as well as running an upgrade.

