### PR TITLE
Remove ini from installer; delete unused queues

### DIFF
--- a/usr/state.json.example
+++ b/usr/state.json.example
@@ -522,7 +522,7 @@
     "dbUrl": "172.17.42.1:5432",
     "dbUsername": "apiuser",
     "rootQueueList":
-      "www.sockets|core.iscan|iscan.isync|iscan.esync|isync.autod|core.barge|barge.acs|barge.ddc|barge.dcl|barge.ecs|barge.gke|barge.triton|core.charon|versions.trigger|core.nf|nf.email|nf.hipchat|nf.irc|nf.slack|nf.webhook|core.braintree|core.certgen|core.hubspotSync|core.marshaller|marshaller.ec2|core.sync|job.request|job.trigger|micro.ini|cluster.init|steps.deploy|steps.manifest|steps.provision|steps.rSync|steps.release|core.logup|www.signals",
+      "www.sockets|core.charon|versions.trigger|core.nf|nf.email|nf.hipchat|nf.irc|nf.slack|nf.webhook|core.braintree|core.certgen|core.hubspotSync|core.marshaller|marshaller.ec2|core.sync|job.request|job.trigger|cluster.init|steps.deploy|steps.manifest|steps.provision|steps.rSync|steps.release|core.logup|www.signals",
     "dbPort": "5432",
     "httpProxy": "",
     "buildTimeoutMS": 3600000,

--- a/versions/master.json
+++ b/versions/master.json
@@ -13,7 +13,6 @@
     "sync",
     "timeTrigger",
     "versionTrigger",
-    "ini",
     "nexec",
     "logup"
   ],
@@ -364,17 +363,6 @@
     },
     {
       "name": "hubspotSync",
-      "repository": "micro",
-      "envs": [
-        "SHIPPABLE_API_TOKEN",
-        "SHIPPABLE_API_URL",
-        "SHIPPABLE_ROOT_AMQP_URL",
-        "SHIPPABLE_AMQP_DEFAULT_EXCHANGE",
-        "COMPONENT"
-      ]
-    },
-    {
-      "name": "ini",
       "repository": "micro",
       "envs": [
         "SHIPPABLE_API_TOKEN",


### PR DESCRIPTION
https://github.com/Shippable/base/issues/1134

- Removes ini queue and other unused queues
- Removes ini from the installed services list

Tested by doing a fresh install and an upgrade. 