### PR TITLE
Do not create the subProviderIdOrgNameI index concurrently

### DIFF
--- a/migrations/master.sql
+++ b/migrations/master.sql
@@ -5747,7 +5747,7 @@ do $$
 
     -- Add subProviderIdOrgNameI Index on subscriptions
     if not exists (select 1 from pg_indexes where tablename = 'subscriptions' and indexname = 'subProviderIdOrgNameI') then
-      create index concurrently "subProviderIdOrgNameI" on "subscriptions" using btree("providerId", "orgName");
+      create index "subProviderIdOrgNameI" on "subscriptions" using btree("providerId", "orgName");
     end if;
 
   end

--- a/migrations/v5.3.2.sql
+++ b/migrations/v5.3.2.sql
@@ -5747,7 +5747,7 @@ do $$
 
     -- Add subProviderIdOrgNameI Index on subscriptions
     if not exists (select 1 from pg_indexes where tablename = 'subscriptions' and indexname = 'subProviderIdOrgNameI') then
-      create index concurrently "subProviderIdOrgNameI" on "subscriptions" using btree("providerId", "orgName");
+      create index "subProviderIdOrgNameI" on "subscriptions" using btree("providerId", "orgName");
     end if;
 
   end


### PR DESCRIPTION
https://github.com/Shippable/base/issues/1170

- No longer tries to create the subProviderIdOrgNameI index concurrently

Tested by upgrading to v.5.2.3 and master, as well as doing a fresh local install with master. The index was created and the migrations ran with no errors each time.